### PR TITLE
Upgrade test deps junit/hamcrest (removes CVE warning on Maven Central)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -62,6 +68,11 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/test/java/me/alexpanov/net/FreePortFinderTest.java
+++ b/src/test/java/me/alexpanov/net/FreePortFinderTest.java
@@ -3,10 +3,12 @@ package me.alexpanov.net;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FreePortFinderTest {
 
@@ -17,9 +19,14 @@ public class FreePortFinderTest {
         assertThat(serverSocket.isBound(), is(true));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void overTheLimitPortAllocationShouldFail() throws Exception {
-        FreePortFinder.findFreeLocalPort(FreePortFinder.MAX_PORT_NUMBER + 1);
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                FreePortFinder.findFreeLocalPort(FreePortFinder.MAX_PORT_NUMBER + 1);
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
Thanks for considering this pull request, it upgrades junit 4 to 5 and includes separate hamcrest matchers.

I would appreciate a new version published, (say 1.1.2) after/if pr is accepted.

yes, it was lighting up [this warning](https://mvnrepository.com/artifact/me.alexpanov/free-port-finder/1.1.1), on a test scope depedency:

![image](https://user-images.githubusercontent.com/66129071/147967159-4e620567-49a8-4940-8d00-6fbed8b2e3bc.png)
